### PR TITLE
Use GeoParquet as default output format

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.10
-  - geopandas>=0.13
+  - geopandas>=0.14
   - h5netcdf
   - tqdm
   - geocube
+  - pyarrow


### PR DESCRIPTION
- New dependency: pyarrow
- `gedi.extract_data`: Default output format when providing `save=True` is now GeoParquet
- `gpkg_to_gdf` was renamed to `load_to_gdf` and accepts both GeoPackage as well as GeoParquet files

Closes #6 