### PR TITLE
feat: `merge_gdf` improvements

### DIFF
--- a/gedixr/xr.py
+++ b/gedixr/xr.py
@@ -26,14 +26,14 @@ def load_to_gdf(l2a: Optional[str | Path] = None,
     -------
     final_gdf: GeoDataFrame
         GeoDataFrame containing the data from the provided GEDI L2A and/or L2B files.
-    """    
+    """
     if all(x is None for x in [l2a, l2b]):
         raise RuntimeError("At least one of the parameters 'l2a' or "
                            "'l2b' must be provided!")
     elif all(x is not None for x in [l2a, l2b]):
         gdf_l2a = _reader(l2a)
         gdf_l2b = _reader(l2b)
-        final_gdf = merge_gdf(gdf_l2a=gdf_l2a, gdf_l2b=gdf_l2b)
+        final_gdf = merge_gdf(l2a=gdf_l2a, l2b=gdf_l2b)
     else:
         fp = l2a if l2a is not None else l2b
         final_gdf = _reader(fp)
@@ -53,83 +53,92 @@ def _reader(fp: str | Path) -> GeoDataFrame:
         raise RuntimeError(f"{fp.suffix} not supported")
 
 
-def merge_gdf(gdf_l2a: GeoDataFrame,
-              gdf_l2b: GeoDataFrame,
-              l2a_variables: Optional[list[str]] = None,
-              l2b_variables: Optional[list[str]] = None
-              ) -> GeoDataFrame:
+def merge_gdf(l2a: GeoDataFrame | dict,
+              l2b: GeoDataFrame | dict,
+              how: str = 'inner',
+              on: Optional[str | list[str]] = None
+              ) -> GeoDataFrame | dict:
     """
-    Merges two GEDI L2A and L2B GeoDataFrames on their `geometry` column.
+    Merges the data of two GeoDataFrames containing GEDI L2A and L2B data. If
+    dictionaries are provided, the function assumes key, value pairs of the dictionary
+    output of `gedi.extract_data`. The function will merge the data of matching
+    geometries and return a dictionary of GeoDataFrames.
     
     Parameters
     ----------
-    gdf_l2a: GeoDataFrame
-        GeoDataFrame containing GEDI L2A data.
-    gdf_l2b: GeoDataFrame
-        GeoDataFrame containing GEDI L2B data.
-    l2a_variables: list of str, optional
-        List of L2A variables to be included in the merged GeoDataFrame.
-        Default is None, which will include default rh98 variable.
-    l2b_variables: list of str, optional
-        List of L2B variables to be included in the merged GeoDataFrame.
-        Default is None, which will include default variables.
+    l2a: GeoDataFrame or dict
+        GeoDataFrame or a dictionary of GeoDataFrames containing GEDI L2A data.
+    l2b: GeoDataFrame or dict
+        GeoDataFrame or a dictionary of GeoDataFrames containing GEDI L2B data.
+    how: str, optional
+        The type of merge to be performed. Default is 'inner'.
+    on: str or list of str, optional
+        The column(s) to merge on. Default is ['geometry', 'shot', 'acq_time'].
     
     Returns
     -------
-    merged_gdf: GeoDataFrame
-        GeoDataFrame containing the data from the provided GEDI L2A and L2B
-        GeoDataFrames.
+    merged_out: GeoDataFrame or dict
+        A GeoDataFrame or a dictionary of GeoDataFrames containing the merged
+        GEDI L2A and L2B data.
     """
-    if type(gdf_l2a)==dict:
-        if len(gdf_l2a.keys()) != len(gdf_l2b.keys()):
-            print(f"WARNING: The GEDI L2A and L2B GeoDataFrames have different "
-                  f"number of AOI's "
-                  f"({len(gdf_l2a.keys())} vs. {len(gdf_l2b.keys())})."
-                  f"\nThey will be merged per AOI, which may lead "
-                  f"to unexpected results and/or missing data.")
-        # loop over the aoi's and merge the dataframes
-        # get the number of aoi's from the longer dictionary
-        nr_aoi = max(len(gdf_l2a.keys()), len(gdf_l2b.keys()))
-        unique_keys = set(gdf_l2a.keys()).union(set(gdf_l2b.keys()))
-        # if lengdf_l2a.keys() > 1, store the merged gdf in a dictionary
-        if nr_aoi > 1:
-            # create a dictionary with the aois as keys and an empty placeholder as value for the gdf
-            merged_gdf_dict = {aoi: {'gdf': None} for aoi in unique_keys}
-        for aoi in gdf_l2a.keys():
-            # convert to geodataframe
-            gdf_l2a_aoi = gdf_l2a[aoi]['gdf']
-            gdf_l2b_aoi = gdf_l2b[aoi]['gdf']
-            if len(gdf_l2a) != len(gdf_l2b):
-                print(f"WARNING: The GEDI L2A and L2B GeoDataFrames have different "
-                    f"number of rows "
-                    f"({len(gdf_l2a)} vs. {len(gdf_l2b)})."
-                    f"\nThey will be merged on their geometry column, which may lead "
-                    f"to unexpected results and/or missing data.")
-            if l2a_variables == None:
-                gdf_l2a_aoi = gdf_l2a_aoi.loc[:, ['rh98', 'geometry']]
-            else:
-                gdf_l2a_aoi = gdf_l2a_aoi.loc[:, l2a_variables + ['geometry']]
-
-            merged_gdf = gdf_l2b_aoi.merge(gdf_l2a_aoi, how='inner', on='geometry')
-            if nr_aoi > 1:
-                # add the merged gdf to the dictionary with aoi as key
-                merged_gdf_dict[aoi] = {'gdf': merged_gdf}
-            else:
-                return merged_gdf
-        return merged_gdf_dict
-
-    if len(gdf_l2a) != len(gdf_l2b):
-        print(f"WARNING: The GEDI L2A and L2B GeoDataFrames have different "
-              f"number of rows "
-              f"({len(gdf_l2a)} vs. {len(gdf_l2b)})."
-              f"\nThey will be merged on their geometry column, which may lead "
-              f"to unexpected results and/or missing data.")
-    if l2a_variables == None:
-        gdf_l2a = gdf_l2a.loc[:, ['rh98', 'geometry']]
+    suffixes = ('_l2a', '_l2b')
+    if on is None:
+        on = ['geometry', 'shot', 'acq_time']
+    if all([isinstance(gdf, dict) for gdf in [l2a, l2b]]):
+        if len(l2a.keys()) != len(l2b.keys()):
+            print(f"WARNING: The provided dictionaries contain data from a "
+                  f"different number of geometries: "
+                  f"({len(l2a.keys())} vs. {len(l2b.keys())})."
+                  f"\nOnly data of matching geometries will be merged and returned.")
+        
+        matched = set(l2a.keys()).intersection(set(l2b.keys()))
+        if len(matched) == 0:
+            raise RuntimeError("No matching geometries found between the provided "
+                               "dictionaries.")
+        
+        merged_out = {}
+        for aoi in matched:
+            _run_checks(l2a[aoi], l2b[aoi], key=aoi)
+            merged_gdf = l2b[aoi]['gdf'].merge(l2a[aoi]['gdf'],
+                                               how=how, on=on, suffixes=suffixes)
+            merged_out[aoi] = {}
+            merged_out[aoi]['gdf'] = merged_gdf
+            merged_out[aoi]['geo'] = l2a[aoi]['geo']
+    elif all([isinstance(gdf, GeoDataFrame) for gdf in [l2a, l2b]]):
+        _compare_gdfs(l2a, l2b)
+        merged_out = l2b.merge(l2a, how=how, on=on, suffixes=suffixes)
     else:
-        gdf_l2a = gdf_l2a.loc[:, l2a_variables + ['geometry']]
-    merged_gdf = gdf_l2b.merge(gdf_l2a, how='inner', on='geometry')
-    return merged_gdf
+        raise RuntimeError("The provided input is not supported.")
+    return merged_out
+
+
+def _run_checks(dict_1: dict,
+                dict_2: dict,
+                key=None) -> None:
+    """Helper function to run checks on two GeoDataFrames to be merged."""
+    if key is None:
+        key = ''
+    else:
+        key = f" of geometry '{key}')"
+        if not dict_1['geo'] == dict_2['geo']:
+            raise RuntimeError(f"The GeoDataFrames{key} contain data from "
+                               f"different geometries, even though they should"
+                               f" match according to their name.")
+    _compare_gdfs(dict_1['gdf'], dict_2['gdf'], key=key)
+
+
+def _compare_gdfs(gdf_1: GeoDataFrame,
+                  gdf_2: GeoDataFrame,
+                  key=None) -> None:
+    """Helper function to compare two GeoDataFrames to be merged."""
+    if not gdf_1.crs == gdf_2.crs:
+        raise RuntimeError(f"The GeoDataFrames{key} are projected in "
+                           f"different coordinate reference systems.")
+    if len(gdf_1) != len(gdf_2):
+        print(f"WARNING: The GeoDataFrames{key} contain different "
+              f"number of rows ({len(gdf_1)} vs. {len(gdf_2)})."
+              f"\nThey will be merged nonetheless, which may result in "
+              f"unexpected results and/or missing data.")
 
 
 def gdf_to_xr(gdf: GeoDataFrame,


### PR DESCRIPTION
- Remove custom variables all together (closes #32 ). Columns can still be dropped afterwards if wanted. 
- Columns with the same name will now be returned with a custom suffix (`_l2a`, `_l2b`) instead of the default (`_x`, `_y`)
- Merging will now happen `on=['geometry', 'shot', 'acq_time']` by default in order to avoid duplicate columns
- The function now accepts the parameters: `on` and `how` to customize the merging. See [`pandas.DataFrame.merge`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.merge.html)
- Additional checks and errors in case something is not as expected (e.g., same geometry key name but different geometries, etc)