### PR TITLE
feat: enable extraction of V003 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ no time!
 - **Quality filtering** built-in with the option to skip and apply custom filters later
 - **Spatial subsetting** using common vector file formats (GeoJSON, GeoPackage, etc.)
 - **GeoParquet output** for efficient storage and processing
+- **Supports version V002 and V003 data** from v0.7.0 onward
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ no time!
 - **Quality filtering** built-in with the option to skip and apply custom filters later
 - **Spatial subsetting** using common vector file formats (GeoJSON, GeoPackage, etc.)
 - **GeoParquet output** for efficient storage and processing
+- **Supports version V002 and V003 data** from v0.7.0 onward
 
 ## Quick Example
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -35,10 +35,10 @@ INFO | GEDI02_B_2024130044637_O30619_04_T06857_02_004_01_V002.h5 |
 ### Output File Naming
 
 The output filename indicates whether default quality filtering was applied by using a 
-suffix after the product type:
+suffix after the product name and version:
 
-- `YYYYMMDDHHMMSS_L2B_1.parquet` - Quality filtering was **enabled**
-- `YYYYMMDDHHMMSS_L2B_0.parquet` - Quality filtering was **disabled**
+- `YYYYMMDDHHMMSS_L2B-V003_1.parquet` - Quality filtering was **enabled**
+- `YYYYMMDDHHMMSS_L2B-V003_0.parquet` - Quality filtering was **disabled**
 
 ## Disabling Quality Filtering
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,11 +61,11 @@ into a single GeoDataFrame while loading.
 ```python
 from gedixr.xr import load_to_gdf
 
-gdf_merged = load_to_gdf(l2a="extracted/20260106_L2A_1.parquet",
-                         l2b="extracted/20260106_L2B_1.parquet")
+gdf_merged = load_to_gdf(l2a="extracted/20260106_L2A-V003_1.parquet",
+                         l2b="extracted/20260106_L2B-V003_1.parquet")
 
 # or load single product:
-gdf_l2b = load_to_gdf(l2b="extracted/20260106_L2B_1.parquet")
+gdf_l2b = load_to_gdf(l2b="extracted/20260106_L2B-V003_1.parquet")
 ```
 
 You can also merge L2A and L2B data directly after extraction using the `merge_gdf` 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -18,7 +18,7 @@ the `variables` parameter (see "Custom Variables" section below).
 
 | Variable | Description | GEDI Layer Name |
 |----------|-------------|-----------------|
-| `rh100` | Height above ground of received waveform signal start | `rh100` |
+| `rh100` | Height above ground of received waveform signal start | `rch[101]` (V003) / `rh100` (V002) |
 | `tcc` | Total canopy cover | `cover` |
 | `fhd` | Foliage Height Diversity | `fhd_normal` |
 | `pai` | Total Plant Area Index | `pai` |
@@ -38,10 +38,13 @@ the `variables` parameter (see "Custom Variables" section below).
 
 ## Further Information
 
-For comprehensive overviews of all available layers in each product:
+- [V003 User Guide](https://lpdaac.usgs.gov/documents/2442/GEDI02_User_Guide_V3.pdf)
+- [L2A-V003 Variables](https://www.earthdata.nasa.gov/data/catalog/lpcloud-gedi02-a-003#variables)
+- [L2B-V003 Variables](https://www.earthdata.nasa.gov/data/catalog/lpcloud-gedi02-b-003#variables)
 
-- [GEDI L2A Product Information](https://lpdaac.usgs.gov/products/gedi02_av002#variables)
-- [GEDI L2B Product Information](https://lpdaac.usgs.gov/products/gedi02_bv002#variables)
+- [V002 User Guide](https://lpdaac.usgs.gov/documents/998/GEDI02_UserGuide_V21.pdf)
+- [L2A-V002 Variables](https://lpdaac.usgs.gov/products/gedi02_av002#variables)
+- [L2B-V002 Variables](https://lpdaac.usgs.gov/products/gedi02_bv002#variables)
 
 ## Custom Variables
 

--- a/gedixr/ancillary.py
+++ b/gedixr/ancillary.py
@@ -23,7 +23,8 @@ error_tracker = ErrorTracker()
 
 def set_logging(
     directory: Path,
-    gedi_product: str
+    gedi_product: str,
+    product_version: str
 ) -> tuple[logging.Logger, str]:
     """
     Set logging for the current process.
@@ -35,6 +36,8 @@ def set_logging(
         '<directory>/log'.
     gedi_product: str
         One of ['L2A', 'L2B']. Used to name the log file.
+    product_version: str
+        One of ['V002', 'V003']. Used to name the log file.
     
     Returns
     -------
@@ -46,7 +49,7 @@ def set_logging(
     log_local = logging.getLogger(__name__)
     log_local.setLevel(logging.DEBUG)
     
-    log_file = directory.joinpath('log', f"{now}_{gedi_product}.log")
+    log_file = directory.joinpath('log', f"{now}_{gedi_product}-{product_version}.log")
     log_file.parent.mkdir(exist_ok=True)
     
     fh = logging.FileHandler(filename=log_file, mode='a')
@@ -103,6 +106,7 @@ def log(
 def initialize_log(
     handler: logging.Logger,
     gedi_product: str,
+    product_version: str,
     variables: list[str],
     beams: list[str],
     filter_month: int | None,
@@ -117,7 +121,9 @@ def initialize_log(
     handler: logging.Logger
         Log handler initiated with the function `set_logging`.
     gedi_product: str
-        One of ['L2A', 'L2B']. Used to name the log file.
+        One of ['L2A', 'L2B'].
+    product_version: str
+        One of ['V002', 'V003'].
     variables: list of str
         List of variables to extract from the GEDI L2A/L2B files.
     beams: list of str
@@ -137,7 +143,7 @@ def initialize_log(
             f"pandas {version('pandas')}, "
             f"geopandas {version('geopandas')}")
     log(handler=handler, mode='info',
-        msg=f"Starting GEDI {gedi_product} data extraction using parameters: "
+        msg=f"Starting GEDI {gedi_product}-{product_version} data extraction using parameters: "
             f"variables={variables}, beams={beams}, "
             f"filter_month={filter_month}, "
             f"subset_vector={subset_vector}, "

--- a/gedixr/cli.py
+++ b/gedixr/cli.py
@@ -32,6 +32,13 @@ def extract(
             help="GEDI product type: 'L2A' or 'L2B'",
         ),
     ] = "L2B",
+    version: Annotated[
+        str,
+        typer.Option(
+            "--version", "-v",
+            help="GEDI product version: 'V002' or 'V003'",
+        ),
+    ] = "V003",
     variables: Annotated[
         str | None,
         typer.Option(
@@ -129,6 +136,7 @@ def extract(
         result, out_path = extract_data(
             directory=directory,
             gedi_product=product,
+            product_version=version,
             variables=variables_list,
             beams=beams_list,
             filter_month=filter_month,

--- a/gedixr/constants.py
+++ b/gedixr/constants.py
@@ -16,29 +16,40 @@ PATTERN_L2B = '*GEDI02_B_*.h5'
 POWER_BEAMS = ['BEAM0101', 'BEAM0110', 'BEAM1000', 'BEAM1011']
 COVERAGE_BEAMS = ['BEAM0000', 'BEAM0001', 'BEAM0010', 'BEAM0011']
 
-DEFAULT_VARIABLES = {'L2A': [('rh98', 'rh98')],
-                     'L2B': [('tcc', 'cover'),
-                             ('fhd', 'fhd_normal'),
-                             ('pai', 'pai'),
-                             ('rh100', 'rh100')]
-                     }
+DEFAULT_VARIABLES = {
+        'L2A': [('rh98', 'rh98')],
+        'L2B': [('tcc', 'cover'),
+                ('fhd', 'fhd_normal'),
+                ('pai', 'pai'),
+                ('rh100', 'rh100')]
+}
 
-DEFAULT_BASE = {'L2A': [('shot', 'shot_number'),
-                        ('latitude', 'lat_lowestmode'),
-                        ('longitude', 'lon_lowestmode'),
-                        ('elev', 'elev_lowestmode'),
-                        ('elev_dem_tdx', 'digital_elevation_model'),
-                        ('degrade_flag', 'degrade_flag'),
-                        ('quality_flag', 'quality_flag'),
-                        ('sensitivity', 'sensitivity'),
-                        ('num_detectedmodes', 'num_detectedmodes')],
-                'L2B': [('shot', 'shot_number'),
-                        ('latitude', 'geolocation/lat_lowestmode'),
-                        ('longitude', 'geolocation/lon_lowestmode'),
-                        ('elev', 'geolocation/elev_lowestmode'),
-                        ('elev_dem_tdx', 'geolocation/digital_elevation_model'),
-                        ('degrade_flag', 'geolocation/degrade_flag'),
-                        ('quality_flag', 'l2b_quality_flag'),
-                        ('sensitivity', 'sensitivity'),
-                        ('num_detectedmodes', 'num_detectedmodes')]
-                 }
+DEFAULT_BASE = {
+        'L2A': [('shot', 'shot_number'),
+                ('latitude', 'lat_lowestmode'),
+                ('longitude', 'lon_lowestmode'),
+                ('elev', 'elev_lowestmode'),
+                ('elev_dem_tdx', 'digital_elevation_model'),
+                ('degrade_flag', 'degrade_flag'),
+                ('quality_flag', 'quality_flag'),
+                ('sensitivity', 'sensitivity'),
+                ('num_detectedmodes', 'num_detectedmodes')],
+        'L2B': [('shot', 'shot_number'),
+                ('latitude', 'geolocation/lat_lowestmode'),
+                ('longitude', 'geolocation/lon_lowestmode'),
+                ('elev', 'geolocation/elev_lowestmode'),
+                ('elev_dem_tdx', 'geolocation/digital_elevation_model'),
+                ('degrade_flag', 'geolocation/degrade_flag'),
+                ('quality_flag', 'l2b_quality_flag'),
+                ('sensitivity', 'sensitivity'),
+                ('num_detectedmodes', 'num_detectedmodes')]
+}
+
+DEFAULT_BASE_V003_CHANGES = {
+        'L2A': {'quality_flag': 'l2a_quality_flag_rel3'},
+        'L2B': {'latitude': 'lat_lowestmode',
+                'longitude': 'lon_lowestmode',
+                'elev': 'elev_lowestmode',
+                'elev_dem_tdx': 'digital_elevation_model',
+                'quality_flag': 'l2b_quality_flag_rel3'}
+}

--- a/gedixr/extract.py
+++ b/gedixr/extract.py
@@ -212,7 +212,7 @@ def extract_data(
             for k, v in out_dict.items():
                 v['path'] = None
                 if v['gdf'] is not None:
-                    out_path = out_dir.joinpath(f'{now}_{gedi_product}_{flt}_{k}.parquet')
+                    out_path = out_dir.joinpath(f'{now}_{gedi_product}-{product_version}_{flt}_{k}.parquet')
                     v['gdf'].to_parquet(out_path)
                     v['path'] = out_path
             return out_dict, None
@@ -221,7 +221,7 @@ def extract_data(
             # make sure that gdf's in list are not all empty 
             if gdf_list_no_spatial_subset:
                 out = pd.concat(gdf_list_no_spatial_subset)
-                out_path = out_dir.joinpath(f'{now}_{gedi_product}_{flt}.parquet')
+                out_path = out_dir.joinpath(f'{now}_{gedi_product}-{product_version}_{flt}.parquet')
                 out.to_parquet(out_path)
             else:
                 anc.log(handler=log_handler, mode='info',

--- a/gedixr/extract.py
+++ b/gedixr/extract.py
@@ -99,9 +99,10 @@ def extract_data(
     directory = anc.to_pathlib(x=directory)
     subset_vector = anc.to_pathlib(x=subset_vector) if \
         (subset_vector is not None) else None
-    log_handler, now = anc.set_logging(directory, gedi_product)
+    log_handler, now = anc.set_logging(directory, gedi_product, product_version)
     anc.initialize_log(handler=log_handler,
                        gedi_product=gedi_product,
+                       product_version=product_version,
                        variables=variables,
                        beams=beams,
                        filter_month=filter_month,
@@ -138,7 +139,7 @@ def extract_data(
         filepaths = [p for p in filepaths if _check_product_version(p, product_version.upper())]
 
         if len(filepaths) == 0:
-            raise RuntimeError(f"No GEDI {gedi_product} files were found in "
+            raise RuntimeError(f"No GEDI {gedi_product}-{product_version} files were found in "
                                f"{directory}.")
         
         gdf_list_no_spatial_subset = []

--- a/gedixr/extract.py
+++ b/gedixr/extract.py
@@ -19,6 +19,7 @@ import gedixr.constants as con
 def extract_data(
     directory: str | Path,
     gedi_product: str,
+    product_version: str = 'V003',
     variables: list[tuple[str, str]] | None = None,
     beams: str | list[str] | None = None,
     filter_month: tuple[int, int] | None = None,
@@ -47,6 +48,8 @@ def extract_data(
         Root directory to recursively search for GEDI L2A/L2B files.
     gedi_product: str
         GEDI product type. Either 'L2A' or 'L2B'. Default is 'L2B'.
+    product_version: str
+        GEDI product version. Either 'V002' or 'V003'. Default is 'V003'.
     variables: list of tuple of str, optional
         List of tuples containing the desired column name in the returned
         GeoDataFrame and the GEDI layer name to be extracted. Defaults to those
@@ -89,7 +92,10 @@ def extract_data(
     if gedi_product not in con.ALLOWED_PRODUCTS:
         raise RuntimeError(f"Parameter 'gedi_product': expected to be one of "
                            f"{con.ALLOWED_PRODUCTS}; got {gedi_product} instead")
-    
+    if product_version not in con.PRODUCT_MAPPING[gedi_product]:
+        raise RuntimeError(f"Parameter 'product_version': expected to be one of "
+                           f"{list(con.PRODUCT_MAPPING[gedi_product].keys())}; got {product_version} instead")
+
     directory = anc.to_pathlib(x=directory)
     subset_vector = anc.to_pathlib(x=subset_vector) if \
         (subset_vector is not None) else None
@@ -122,13 +128,15 @@ def extract_data(
         filter_month = (1, 12)
     if subset_vector is not None:
         out_dict = anc.prepare_vec(vec=subset_vector)
-    layers = con.DEFAULT_BASE[gedi_product] + variables
     
+    # Get the base variables for the specified product and version, applying overrides for V003
+    layers = _get_base_variables(gedi_product, product_version) + variables
+
     try:
         # (1) Search for GEDI files
-        filepaths = [p for p in directory.rglob('*') if p.is_file() and
-                     p.match(pattern)]
-        
+        filepaths = [p for p in directory.rglob('*') if p.is_file() and p.match(pattern)]
+        filepaths = [p for p in filepaths if _check_product_version(p, product_version.upper())]
+
         if len(filepaths) == 0:
             raise RuntimeError(f"No GEDI {gedi_product} files were found in "
                                f"{directory}.")
@@ -153,6 +161,7 @@ def extract_data(
                 df = pd.DataFrame(_from_file(gedi=gedi,
                                              gedi_fp=fp,
                                              gedi_product=gedi_product,
+                                             product_version=product_version,
                                              beams=beams,
                                              layers=layers,
                                              acq_time=date,
@@ -230,6 +239,41 @@ def extract_data(
                   f"process. Please check the log file!")
 
 
+def _check_product_version(path: Path, version: str) -> bool:
+    """ Checks if a given GEDI file path corresponds to the specified product version."""
+    name = path.name
+    regex = re.compile(rf'[_\.]?{re.escape(version)}.*\.h5$', re.IGNORECASE)
+    return regex.search(name) is not None
+
+
+def _get_base_variables(
+    product: str,
+    version: str,
+    base_dict: dict[str, list[tuple[str, str]]] = con.DEFAULT_BASE,
+    override_dict: dict[str, dict[str, str]] = con.DEFAULT_BASE_V003_CHANGES,
+) -> list[tuple[str, str]]:
+    """ Returns the base variables for a given product and version, applying overrides for V003 if necessary."""
+    base_vars = base_dict[product]
+
+    if version == 'V002':
+        return base_vars
+    if version == 'V003':
+        overrides = override_dict.get(product, {})
+        if not overrides:
+            return base_vars
+
+        # Build a mapping from output_name -> (output_name, hdf_path)
+        var_map = {name: (name, path) for name, path in base_vars}
+
+        # Apply overrides: replace hdf_path for matching output_name
+        for name, new_path in overrides.items():
+            if name in var_map:
+                var_map[name] = (name, new_path)
+        
+        return list(var_map.values())
+    raise ValueError(f"Unsupported version: {version}")
+
+
 def _date_from_gedi_file(gedi_path: Path) -> datetime:
     """Extract date string from GEDI filename and convert to datetime object."""
     date_str = re.search('[AB]_[0-9]{13}', gedi_path.name).group()
@@ -241,6 +285,7 @@ def _from_file(
     gedi: h5py.File,
     gedi_fp: Path,
     gedi_product: str,
+    product_version: str,
     beams: list[str],
     layers: list[tuple[str, str]],
     acq_time: datetime,
@@ -257,6 +302,8 @@ def _from_file(
         Path to the current GEDI HDF5 file.
     gedi_product: str
         GEDI product type. Either 'L2A' or 'L2B'.
+    product_version: str
+        GEDI product version. Either 'V002' or 'V003'.
     beams: list of str
         List of GEDI beams to extract values from.
     layers: list of tuple of str
@@ -298,6 +345,10 @@ def _from_file(
                 if v.startswith("rh") and gedi_product == "L2A":
                     idx = int(v[2:])
                     vals = [round(h_bin[idx] * 100) for h_bin in gedi[f"{beam}/rh"][()]]
+                elif v.startswith(("rh", "rch")) and gedi_product == "L2B" and product_version == "V003":
+                    m = re.search(r'(\d+)$', v)
+                    idx = int(m.group(1)) if m else None
+                    vals = [h_bin[idx] for h_bin in gedi[f"{beam}/rch"][()]]
                 elif v == "shot_number":
                     vals = [f"{_id:0>18}" for _id in shot_raw]
                 else:


### PR DESCRIPTION
This pull request adds support for new V003 L2A and L2B data. It introduces a new `product_version` parameter to the extraction workflow, updates file naming conventions, and ensures correct variable mapping and logging for each product version. The documentation is also updated to reflect these changes, including new links and usage examples.

**Support for Multiple GEDI Product Versions:**
* Added a `product_version` parameter (defaulting to `'V003'`) to the CLI, extraction, and logging functions, allowing explicit selection between V002 and V003 datasets. The code now validates and filters files by version and applies version-specific variable mappings.
* Introduced version-specific overrides for variable names and HDF5 paths, especially for V003, ensuring correct data extraction for each version. 

**File Naming and Logging Updates:**
* Updated output file and log naming conventions to include the product version, improving traceability and clarity. 

**Documentation Improvements:**
* Revised documentation and usage examples to reflect support for both V002 and V003, updated variable descriptions, and added links to the relevant user guides and variable lists for each version.

**Variable Mapping Enhancements:**
* Improved handling of variable mapping for differences between V002 and V003, including logic for new or renamed fields (e.g., `rh100` → `rch[101]` in V003).

**CLI and API Consistency:**
* Ensured that the CLI, API, and internal functions consistently accept and propagate the `product_version` parameter

closes #67 